### PR TITLE
Set ISR memory to 0 for consistent `fetch` caching accross nodes in pm2

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,7 @@ const nextConfig = {
   reactStrictMode: true,
   output: "standalone",
   experimental: {
+    isrMemoryCacheSize: 0,
     serverActions: true,
     logging: "verbose",
   },


### PR DESCRIPTION
Nextjs by default caches ISR data & fetch cache in memory for faster accesses, but it result in inconsistent results when a user accesses the site because The site is deployed on `pm2` with 2 instances and each instance is revalidated at a different time.

Reducing the memory to `0` disables it and make it so that it always use the file-system for caching.

I may also use this for caching https://nextjs.org/docs/app/api-reference/next-config-js/incrementalCacheHandlerPath