### PR TITLE
Fix DB performance

### DIFF
--- a/drizzle/0035_deep_mephisto.sql
+++ b/drizzle/0035_deep_mephisto.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS "author_fk_idx" ON "gh_next_comments" ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issue_fk_idx" ON "gh_next_comments" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "repository_fk_idx" ON "gh_next_issues" ("repository_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "author_fk_idx" ON "gh_next_issues" ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "creator_fk_idx" ON "gh_next_repositories" ("creator_id");

--- a/drizzle/0036_careful_freak.sql
+++ b/drizzle/0036_careful_freak.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "author_fk_idx" ON "gh_next_reactions" ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issue_fk_idx" ON "gh_next_reactions" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "comment_fk_idx" ON "gh_next_reactions" ("comment_id");

--- a/drizzle/0037_cynical_peter_parker.sql
+++ b/drizzle/0037_cynical_peter_parker.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS "author_fk_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "issue_fk_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "comment_fk_idx";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rakt_author_fk_idx" ON "gh_next_reactions" ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rakt_issue_fk_idx" ON "gh_next_reactions" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rakt_comment_fk_idx" ON "gh_next_reactions" ("comment_id");

--- a/drizzle/0038_common_hiroim.sql
+++ b/drizzle/0038_common_hiroim.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "gh_next_issues" DROP CONSTRAINT "uniq_number_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "author_fk_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "issue_fk_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "repository_fk_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "name_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "creator_fk_idx";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "com_author_fk_idx" ON "gh_next_comments" ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "com_issue_fk_idx" ON "gh_next_comments" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "iss_repo_fk_idx" ON "gh_next_issues" ("repository_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "iss_author_fk_idx" ON "gh_next_issues" ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ment_username_idx" ON "gh_next_issue_user_mentions" ("username");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "repo_name_idx" ON "gh_next_repositories" ("name");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "repo_creator_fk_idx" ON "gh_next_repositories" ("creator_id");--> statement-breakpoint
+ALTER TABLE "gh_next_issues" ADD CONSTRAINT "iss_uniq_number_idx" UNIQUE("repository_id","number");

--- a/drizzle/0039_marvelous_mercury.sql
+++ b/drizzle/0039_marvelous_mercury.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "iss_status_idx" ON "gh_next_issues" ("status");

--- a/drizzle/0040_awesome_leech.sql
+++ b/drizzle/0040_awesome_leech.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "gh_next_issues" ALTER COLUMN "title" SET DATA TYPE varchar(500);

--- a/drizzle/0041_damp_jack_murdock.sql
+++ b/drizzle/0041_damp_jack_murdock.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "com_author_uname_idx" ON "gh_next_comments" ("author_username");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "iss_author_uname_idx" ON "gh_next_issues" ("author_username");

--- a/drizzle/0042_gorgeous_doctor_spectrum.sql
+++ b/drizzle/0042_gorgeous_doctor_spectrum.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "rakt_type_idx" ON "gh_next_reactions" ("author_id");

--- a/drizzle/0043_blue_tusk.sql
+++ b/drizzle/0043_blue_tusk.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "rakt_type_idx";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rakt_type_idx" ON "gh_next_reactions" ("type");

--- a/drizzle/0044_brainy_jazinda.sql
+++ b/drizzle/0044_brainy_jazinda.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "ment_issue_idx" ON "gh_next_issue_user_mentions" ("issue_id");

--- a/drizzle/0045_bent_roulette.sql
+++ b/drizzle/0045_bent_roulette.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS "title_idx";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "iss_title_idx" ON "gh_next_issues" ("title");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "iss_created_idx" ON "gh_next_issues" ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "iss_updated_idx" ON "gh_next_issues" ("updated_at");

--- a/drizzle/0046_square_ikaris.sql
+++ b/drizzle/0046_square_ikaris.sql
@@ -1,0 +1,25 @@
+-- Custom SQL migration file, put you code below! --
+CREATE MATERIALIZED VIEW comment_count_per_issue AS
+SELECT
+    issue_id,
+    COUNT(id) AS comment_count
+FROM
+    gh_next_comments
+GROUP BY
+    issue_id; --> statement-breakpoint
+
+CREATE MATERIALIZED VIEW reaction_count_per_issue AS
+SELECT
+    issue_id,
+    COALESCE(SUM(CASE WHEN type = 'PLUS_ONE' THEN 1 ELSE 0 END), 0) AS plus_one_count,
+    COALESCE(SUM(CASE WHEN type = 'MINUS_ONE' THEN 1 ELSE 0 END), 0) AS minus_one_count,
+    COALESCE(SUM(CASE WHEN type = 'CONFUSED' THEN 1 ELSE 0 END), 0) AS confused_count,
+    COALESCE(SUM(CASE WHEN type = 'EYES' THEN 1 ELSE 0 END), 0) AS eyes_count,
+    COALESCE(SUM(CASE WHEN type = 'HEART' THEN 1 ELSE 0 END), 0) AS heart_count,
+    COALESCE(SUM(CASE WHEN type = 'HOORAY' THEN 1 ELSE 0 END), 0) AS hooray_count,
+    COALESCE(SUM(CASE WHEN type = 'LAUGH' THEN 1 ELSE 0 END), 0) AS laugh_count,
+    COALESCE(SUM(CASE WHEN type = 'ROCKET' THEN 1 ELSE 0 END), 0) AS rocket_count
+FROM
+    gh_next_reactions
+GROUP BY
+    issue_id;

--- a/drizzle/0047_same_stark_industries.sql
+++ b/drizzle/0047_same_stark_industries.sql
@@ -1,0 +1,3 @@
+-- Custom SQL migration file, put you code below! --
+CREATE INDEX IF NOT EXISTS "comment_count_issue_id_idx" ON "comment_count_per_issue" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reaction_count_issue_id_idx" ON "reaction_count_per_issue" ("issue_id");

--- a/drizzle/0048_dusty_leper_queen.sql
+++ b/drizzle/0048_dusty_leper_queen.sql
@@ -1,0 +1,29 @@
+-- Custom SQL migration file, put you code below! --
+CREATE OR REPLACE FUNCTION refresh_comment_count_per_issue()
+RETURNS TRIGGER AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY comment_count_per_issue;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION refresh_reaction_count_per_issue()
+RETURNS TRIGGER AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY reaction_count_per_issue;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+
+CREATE TRIGGER trigger_refresh_comment_count
+AFTER INSERT OR DELETE
+ON gh_next_comments
+FOR EACH ROW
+EXECUTE FUNCTION refresh_comment_count_per_issue();--> statement-breakpoint
+
+CREATE TRIGGER trigger_refresh_reaction_count
+AFTER INSERT OR DELETE
+ON gh_next_reactions
+FOR EACH ROW
+EXECUTE FUNCTION refresh_reaction_count_per_issue();

--- a/drizzle/0049_flowery_ikaris.sql
+++ b/drizzle/0049_flowery_ikaris.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "is_2_ass_issue_fk_index" ON "gh_next_issues_to_assignees" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "is_2_ass_assignee_fk_index" ON "gh_next_issues_to_assignees" ("assignee_id");

--- a/drizzle/0050_special_blue_blade.sql
+++ b/drizzle/0050_special_blue_blade.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "lbl_2_iss_issue_fk_index" ON "gh_next_labels_to_issues" ("issue_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lbl_2_iss_assignee_fk_index" ON "gh_next_labels_to_issues" ("label_id");

--- a/drizzle/meta/0035_snapshot.json
+++ b/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,1159 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "a4a2220e-230e-49fc-bce5-0e65a2c8d279",
+  "prevId": "fd4dd2bd-04c5-4eee-89ef-9435f9cf71dd",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "issue_fk_idx": {
+          "name": "issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "repository_fk_idx": {
+          "name": "repository_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_number_idx": {
+          "name": "uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "creator_fk_idx": {
+          "name": "creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0036_snapshot.json
+++ b/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,1181 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "917e614a-73d2-4c0e-8661-35ee6865d468",
+  "prevId": "a4a2220e-230e-49fc-bce5-0e65a2c8d279",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "issue_fk_idx": {
+          "name": "issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "repository_fk_idx": {
+          "name": "repository_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_number_idx": {
+          "name": "uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "issue_fk_idx": {
+          "name": "issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "comment_fk_idx": {
+          "name": "comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "creator_fk_idx": {
+          "name": "creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0037_snapshot.json
+++ b/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,1181 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "d7877c73-ed0a-4160-a857-c9500fa698d2",
+  "prevId": "917e614a-73d2-4c0e-8661-35ee6865d468",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "issue_fk_idx": {
+          "name": "issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "repository_fk_idx": {
+          "name": "repository_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "author_fk_idx": {
+          "name": "author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uniq_number_idx": {
+          "name": "uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "creator_fk_idx": {
+          "name": "creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0038_snapshot.json
+++ b/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,1189 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "7554e6aa-4468-4536-af8f-540bfdcfe433",
+  "prevId": "d7877c73-ed0a-4160-a857-c9500fa698d2",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0039_snapshot.json
+++ b/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,1196 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "05c4236d-19c1-4bba-accc-d9437ee3c9ab",
+  "prevId": "7554e6aa-4468-4536-af8f-540bfdcfe433",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0040_snapshot.json
+++ b/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,1196 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "1b1e6e51-8e9c-43b1-ae68-8ec717300ec7",
+  "prevId": "05c4236d-19c1-4bba-accc-d9437ee3c9ab",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0041_snapshot.json
+++ b/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,1210 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "0becd661-231e-438d-9231-01db34ef7e96",
+  "prevId": "1b1e6e51-8e9c-43b1-ae68-8ec717300ec7",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0042_snapshot.json
+++ b/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,1217 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "32c956ff-66b9-4c4d-848d-ce2dc77251db",
+  "prevId": "0becd661-231e-438d-9231-01db34ef7e96",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0043_snapshot.json
+++ b/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,1217 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "1b63f816-1e26-4913-9be5-323e1052a141",
+  "prevId": "32c956ff-66b9-4c4d-848d-ce2dc77251db",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0044_snapshot.json
+++ b/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,1224 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "aeec7f57-32fb-466b-b822-80f0c9e84da4",
+  "prevId": "1b63f816-1e26-4913-9be5-323e1052a141",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "title_idx": {
+          "name": "title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0045_snapshot.json
+++ b/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,1238 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "06c84e25-4be0-4c00-b8bb-e2ed72d1da45",
+  "prevId": "aeec7f57-32fb-466b-b822-80f0c9e84da4",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "iss_title_idx": {
+          "name": "iss_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_created_idx": {
+          "name": "iss_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "iss_updated_idx": {
+          "name": "iss_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0046_snapshot.json
+++ b/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,1238 @@
+{
+  "id": "aa9be314-c219-4371-80c9-116db13be167",
+  "prevId": "06c84e25-4be0-4c00-b8bb-e2ed72d1da45",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "gh_next_labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "iss_title_idx": {
+          "name": "iss_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_created_idx": {
+          "name": "iss_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "iss_updated_idx": {
+          "name": "iss_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "tableTo": "gh_next_repositories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "columns": [
+            "repository_id",
+            "number"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "gh_next_labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0047_snapshot.json
+++ b/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,1238 @@
+{
+  "id": "473c5ac0-f1dc-4b06-b51b-fca70ebfcfbb",
+  "prevId": "aa9be314-c219-4371-80c9-116db13be167",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "gh_next_labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "iss_title_idx": {
+          "name": "iss_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_created_idx": {
+          "name": "iss_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "iss_updated_idx": {
+          "name": "iss_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "tableTo": "gh_next_repositories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "columns": [
+            "repository_id",
+            "number"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "gh_next_labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0048_snapshot.json
+++ b/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,1238 @@
+{
+  "id": "ec25e65e-9df7-41bc-910d-112e11fb02ce",
+  "prevId": "473c5ac0-f1dc-4b06-b51b-fca70ebfcfbb",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "gh_next_labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "iss_title_idx": {
+          "name": "iss_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_created_idx": {
+          "name": "iss_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "iss_updated_idx": {
+          "name": "iss_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "tableTo": "gh_next_repositories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "columns": [
+            "repository_id",
+            "number"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "gh_next_labels",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "gh_next_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "gh_next_issues",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "tableTo": "gh_next_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0049_snapshot.json
+++ b/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,1253 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "71cc65a3-4b67-4031-bffa-609e6cd6505c",
+  "prevId": "ec25e65e-9df7-41bc-910d-112e11fb02ce",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "is_2_ass_issue_fk_index": {
+          "name": "is_2_ass_issue_fk_index",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "is_2_ass_assignee_fk_index": {
+          "name": "is_2_ass_assignee_fk_index",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "iss_title_idx": {
+          "name": "iss_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_created_idx": {
+          "name": "iss_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "iss_updated_idx": {
+          "name": "iss_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/0050_snapshot.json
+++ b/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,1268 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "493d1a46-6002-49c8-a9e6-85d96dc0d538",
+  "prevId": "71cc65a3-4b67-4031-bffa-609e6cd6505c",
+  "tables": {
+    "gh_next_comment_revisions": {
+      "name": "gh_next_comment_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_content": {
+          "name": "updated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_comment_revisions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_comment_revisions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_comments": {
+      "name": "gh_next_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "comment_hide_reason",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "com_author_fk_idx": {
+          "name": "com_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "com_author_uname_idx": {
+          "name": "com_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        },
+        "com_issue_fk_idx": {
+          "name": "com_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_comments_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_comments_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_comments_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_comments_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_comments",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_events": {
+      "name": "gh_next_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "initiator_id": {
+          "name": "initiator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiator_username": {
+          "name": "initiator_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_avatar_url": {
+          "name": "initiator_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentionned_issue_id": {
+          "name": "mentionned_issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_events_initiator_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_events_initiator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_events_mentionned_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "mentionned_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_issue_events_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_events_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_events_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_events",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_revisions": {
+      "name": "gh_next_issue_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revised_by_username": {
+          "name": "revised_by_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revised_by_avatar_url": {
+          "name": "revised_by_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_description": {
+          "name": "updated_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_revisions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_revisions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues_to_assignees": {
+      "name": "gh_next_issues_to_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignee_username": {
+          "name": "assignee_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_avatar_url": {
+          "name": "assignee_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "is_2_ass_issue_fk_index": {
+          "name": "is_2_ass_issue_fk_index",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "is_2_ass_assignee_fk_index": {
+          "name": "is_2_ass_assignee_fk_index",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issues_to_assignees_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_to_assignees_assignee_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues_to_assignees",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issue_user_subscriptions": {
+      "name": "gh_next_issue_user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_user_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_subscriptions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_subscriptions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_issues": {
+      "name": "gh_next_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "issue_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lock_reason": {
+          "name": "lock_reason",
+          "type": "issue_lock_reason",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "iss_title_idx": {
+          "name": "iss_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "iss_created_idx": {
+          "name": "iss_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "iss_updated_idx": {
+          "name": "iss_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "iss_status_idx": {
+          "name": "iss_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "iss_repo_fk_idx": {
+          "name": "iss_repo_fk_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_fk_idx": {
+          "name": "iss_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "iss_author_uname_idx": {
+          "name": "iss_author_uname_idx",
+          "columns": [
+            "author_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issues_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_issues_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_issues_repository_id_gh_next_repositories_id_fk": {
+          "name": "gh_next_issues_repository_id_gh_next_repositories_id_fk",
+          "tableFrom": "gh_next_issues",
+          "tableTo": "gh_next_repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iss_uniq_number_idx": {
+          "name": "iss_uniq_number_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      }
+    },
+    "gh_next_labels_to_issues": {
+      "name": "gh_next_labels_to_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lbl_2_iss_issue_fk_index": {
+          "name": "lbl_2_iss_issue_fk_index",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "lbl_2_iss_assignee_fk_index": {
+          "name": "lbl_2_iss_assignee_fk_index",
+          "columns": [
+            "label_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_labels_to_issues_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk": {
+          "name": "gh_next_labels_to_issues_label_id_gh_next_labels_id_fk",
+          "tableFrom": "gh_next_labels_to_issues",
+          "tableTo": "gh_next_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_next_labels_to_issues_issue_id_label_id": {
+          "name": "gh_next_labels_to_issues_issue_id_label_id",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "gh_next_labels": {
+      "name": "gh_next_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_labels_name_unique": {
+          "name": "gh_next_labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_issue_user_mentions": {
+      "name": "gh_next_issue_user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ment_username_idx": {
+          "name": "ment_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        },
+        "ment_issue_idx": {
+          "name": "ment_issue_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_issue_user_mentions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_issue_user_mentions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_issue_user_mentions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_issue_user_mentions_username_issue_id_comment_id_unique": {
+          "name": "gh_next_issue_user_mentions_username_issue_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "issue_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "gh_next_reactions": {
+      "name": "gh_next_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rakt_author_fk_idx": {
+          "name": "rakt_author_fk_idx",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_type_idx": {
+          "name": "rakt_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "rakt_issue_fk_idx": {
+          "name": "rakt_issue_fk_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "rakt_comment_fk_idx": {
+          "name": "rakt_comment_fk_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_reactions_author_id_gh_next_users_id_fk": {
+          "name": "gh_next_reactions_author_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_comment_id_gh_next_comments_id_fk": {
+          "name": "gh_next_reactions_comment_id_gh_next_comments_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_next_reactions_issue_id_gh_next_issues_id_fk": {
+          "name": "gh_next_reactions_issue_id_gh_next_issues_id_fk",
+          "tableFrom": "gh_next_reactions",
+          "tableTo": "gh_next_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "gh_next_repositories": {
+      "name": "gh_next_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_name_idx": {
+          "name": "repo_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repo_creator_fk_idx": {
+          "name": "repo_creator_fk_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gh_next_repositories_creator_id_gh_next_users_id_fk": {
+          "name": "gh_next_repositories_creator_id_gh_next_users_id_fk",
+          "tableFrom": "gh_next_repositories",
+          "tableTo": "gh_next_users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_repositories_name_unique": {
+          "name": "gh_next_repositories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "gh_next_users": {
+      "name": "gh_next_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_theme": {
+          "name": "preferred_theme",
+          "type": "themes",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_next_users_username_unique": {
+          "name": "gh_next_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "gh_next_users_github_id_unique": {
+          "name": "gh_next_users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "comment_hide_reason": {
+      "name": "comment_hide_reason",
+      "values": {
+        "ABUSE": "ABUSE",
+        "OFF_TOPIC": "OFF_TOPIC",
+        "OUTDATED": "OUTDATED",
+        "RESOLVED": "RESOLVED",
+        "DUPLICATE": "DUPLICATE",
+        "SPAM": "SPAM"
+      }
+    },
+    "event_type": {
+      "name": "event_type",
+      "values": {
+        "CHANGE_TITLE": "CHANGE_TITLE",
+        "TOGGLE_STATUS": "TOGGLE_STATUS",
+        "ISSUE_MENTION": "ISSUE_MENTION",
+        "ASSIGN_USER": "ASSIGN_USER",
+        "ADD_LABEL": "ADD_LABEL",
+        "REMOVE_LABEL": "REMOVE_LABEL",
+        "ADD_COMMENT": "ADD_COMMENT"
+      }
+    },
+    "issue_lock_reason": {
+      "name": "issue_lock_reason",
+      "values": {
+        "OFF_TOPIC": "OFF_TOPIC",
+        "TOO_HEATED": "TOO_HEATED",
+        "RESOLVED": "RESOLVED",
+        "SPAM": "SPAM"
+      }
+    },
+    "issue_status": {
+      "name": "issue_status",
+      "values": {
+        "OPEN": "OPEN",
+        "CLOSED": "CLOSED",
+        "NOT_PLANNED": "NOT_PLANNED"
+      }
+    },
+    "reaction_type": {
+      "name": "reaction_type",
+      "values": {
+        "PLUS_ONE": "PLUS_ONE",
+        "MINUS_ONE": "MINUS_ONE",
+        "LAUGH": "LAUGH",
+        "CONFUSED": "CONFUSED",
+        "HEART": "HEART",
+        "HOORAY": "HOORAY",
+        "ROCKET": "ROCKET",
+        "EYES": "EYES"
+      }
+    },
+    "themes": {
+      "name": "themes",
+      "values": {
+        "dark": "dark",
+        "light": "light",
+        "system": "system"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1700332792302,
       "tag": "0049_flowery_ikaris",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "5",
+      "when": 1700333438623,
+      "tag": "0050_special_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,104 @@
       "when": 1700017366148,
       "tag": "0034_rainy_ezekiel",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "5",
+      "when": 1700323931026,
+      "tag": "0035_deep_mephisto",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "5",
+      "when": 1700324463027,
+      "tag": "0036_careful_freak",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "5",
+      "when": 1700324570464,
+      "tag": "0037_cynical_peter_parker",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "5",
+      "when": 1700325285272,
+      "tag": "0038_common_hiroim",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "5",
+      "when": 1700325436400,
+      "tag": "0039_marvelous_mercury",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "5",
+      "when": 1700325800063,
+      "tag": "0040_awesome_leech",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "5",
+      "when": 1700327242437,
+      "tag": "0041_damp_jack_murdock",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "5",
+      "when": 1700328085271,
+      "tag": "0042_gorgeous_doctor_spectrum",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "5",
+      "when": 1700328172762,
+      "tag": "0043_blue_tusk",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "5",
+      "when": 1700328579730,
+      "tag": "0044_brainy_jazinda",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "5",
+      "when": 1700328712425,
+      "tag": "0045_bent_roulette",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "5",
+      "when": 1700329739162,
+      "tag": "0046_square_ikaris",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "5",
+      "when": 1700330524431,
+      "tag": "0047_same_stark_industries",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "5",
+      "when": 1700331636048,
+      "tag": "0048_dusty_leper_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1700331636048,
       "tag": "0048_dusty_leper_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "5",
+      "when": 1700332792302,
+      "tag": "0049_flowery_ikaris",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(models)/issues/search.ts
+++ b/src/app/(models)/issues/search.ts
@@ -17,18 +17,14 @@ import {
   IN_FILTERS,
   UN_MATCHABLE_USERNAME
 } from "~/lib/shared/constants";
-import {
-  ReactionTypes,
-  reactions,
-  reactionsCountPerIssue
-} from "~/lib/server/db/schema/reaction.sql";
+import { reactionsCountPerIssue } from "~/lib/server/db/schema/reaction.sql";
 import { issueUserMentions } from "~/lib/server/db/schema/mention.sql";
 import { alias } from "drizzle-orm/pg-core";
+import { repositories } from "~/lib/server/db/schema/repository.sql";
 
 import type { User } from "~/lib/server/db/schema/user.sql";
 import type { SQL } from "drizzle-orm";
 import type { IssueSearchFilters } from "~/lib/shared/utils.shared";
-import { repositories } from "~/lib/server/db/schema/repository.sql";
 
 /**
  * Main function to search for issues

--- a/src/lib/server/db/schema/comment.sql.ts
+++ b/src/lib/server/db/schema/comment.sql.ts
@@ -6,9 +6,10 @@ import {
   varchar,
   boolean,
   pgEnum,
-  index
+  index,
+  pgMaterializedView
 } from "drizzle-orm/pg-core";
-import { relations, sql } from "drizzle-orm";
+import { eq, relations, sql } from "drizzle-orm";
 import { pgTable, tsVector } from "./index.sql";
 
 import { users } from "./user.sql";
@@ -29,23 +30,45 @@ export const commentHideReasonEnum = pgEnum("comment_hide_reason", [
 export type CommentHideReason =
   (typeof commentHideReasonEnum)["enumValues"][number];
 
-export const comments = pgTable("comments", {
-  id: serial("id").primaryKey(),
-  content: text("content").notNull(),
-  created_at: timestamp("created_at").defaultNow().notNull(),
-  author_id: integer("author_id").references(() => users.id, {
-    onDelete: "set null"
-  }),
-  author_username: varchar("author_username", { length: 255 }).notNull(),
-  author_avatar_url: varchar("author_avatar_url", { length: 255 }).notNull(),
-  issue_id: integer("issue_id")
-    .references(() => issues.id, {
-      onDelete: "cascade"
+export const comments = pgTable(
+  "comments",
+  {
+    id: serial("id").primaryKey(),
+    content: text("content").notNull(),
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    author_id: integer("author_id").references(() => users.id, {
+      onDelete: "set null"
+    }),
+    author_username: varchar("author_username", { length: 255 }).notNull(),
+    author_avatar_url: varchar("author_avatar_url", { length: 255 }).notNull(),
+    issue_id: integer("issue_id")
+      .references(() => issues.id, {
+        onDelete: "cascade"
+      })
+      .notNull(),
+    hidden: boolean("hidden").default(false).notNull(),
+    hidden_reason: commentHideReasonEnum("hidden_reason")
+  },
+  (table) => ({
+    authorFKIdx: index("com_author_fk_idx").on(table.author_id),
+    authorUsernameIdx: index("com_author_uname_idx").on(table.author_username),
+    issueFKIdx: index("com_issue_fk_idx").on(table.issue_id)
+  })
+);
+
+export const commentsCountPerIssue = pgMaterializedView(
+  "comment_count_per_issue"
+).as((qb) =>
+  qb
+    .select({
+      issue_id: comments.issue_id,
+      comment_count: sql<number>`count(${comments.id})`
+        .mapWith(Number)
+        .as("comment_count")
     })
-    .notNull(),
-  hidden: boolean("hidden").default(false).notNull(),
-  hidden_reason: commentHideReasonEnum("hidden_reason")
-});
+    .from(comments)
+    .groupBy(comments.issue_id)
+);
 
 export const commentsRelations = relations(comments, ({ one, many }) => ({
   author: one(users, {

--- a/src/lib/server/db/schema/comment.sql.ts
+++ b/src/lib/server/db/schema/comment.sql.ts
@@ -9,8 +9,8 @@ import {
   index,
   pgMaterializedView
 } from "drizzle-orm/pg-core";
-import { eq, relations, sql } from "drizzle-orm";
-import { pgTable, tsVector } from "./index.sql";
+import { relations, sql } from "drizzle-orm";
+import { pgTable } from "./index.sql";
 
 import { users } from "./user.sql";
 import { issues } from "./issue.sql";

--- a/src/lib/server/db/schema/issue.sql.ts
+++ b/src/lib/server/db/schema/issue.sql.ts
@@ -47,7 +47,7 @@ export const issues = pgTable(
   {
     id: serial("id").primaryKey(),
     number: integer("number").notNull(),
-    title: text("title").notNull(),
+    title: varchar("title", { length: 500 }).notNull(),
     body: text("body").default("").notNull(),
     created_at: timestamp("created_at").defaultNow().notNull(),
     updated_at: timestamp("updated_at").defaultNow().notNull(),
@@ -67,8 +67,14 @@ export const issues = pgTable(
       .notNull()
   },
   (table) => ({
-    titleIdx: index("title_idx").on(table.title),
-    uniqNumberIdx: unique("uniq_number_idx").on(
+    titleIdx: index("iss_title_idx").on(table.title),
+    createdAtIdx: index("iss_created_idx").on(table.created_at),
+    updatedAtIdx: index("iss_updated_idx").on(table.updated_at),
+    statusIdx: index("iss_status_idx").on(table.status),
+    repositoryFKIdx: index("iss_repo_fk_idx").on(table.repository_id),
+    authorFKIdx: index("iss_author_fk_idx").on(table.author_id),
+    authorUsernameIdx: index("iss_author_uname_idx").on(table.author_username),
+    uniqNumberIdx: unique("iss_uniq_number_idx").on(
       table.repository_id,
       table.number
     )

--- a/src/lib/server/db/schema/issue.sql.ts
+++ b/src/lib/server/db/schema/issue.sql.ts
@@ -107,21 +107,28 @@ export const issuesRelations = relations(issues, ({ one, many }) => ({
   })
 }));
 
-export const issueToAssignees = pgTable("issues_to_assignees", {
-  id: serial("id").primaryKey(),
-  assignee_username: varchar("assignee_username", {
-    length: 255
-  }).notNull(),
-  assignee_avatar_url: varchar("assignee_avatar_url", {
-    length: 255
-  }).notNull(),
-  issue_id: integer("issue_id")
-    .references(() => issues.id)
-    .notNull(),
-  assignee_id: integer("assignee_id").references(() => users.id, {
-    onDelete: "cascade"
+export const issueToAssignees = pgTable(
+  "issues_to_assignees",
+  {
+    id: serial("id").primaryKey(),
+    assignee_username: varchar("assignee_username", {
+      length: 255
+    }).notNull(),
+    assignee_avatar_url: varchar("assignee_avatar_url", {
+      length: 255
+    }).notNull(),
+    issue_id: integer("issue_id")
+      .references(() => issues.id)
+      .notNull(),
+    assignee_id: integer("assignee_id").references(() => users.id, {
+      onDelete: "cascade"
+    })
+  },
+  (table) => ({
+    issueFkIndex: index("is_2_ass_issue_fk_index").on(table.issue_id),
+    assigneeFkIndex: index("is_2_ass_assignee_fk_index").on(table.assignee_id)
   })
-});
+);
 
 export const issueToAssigneesRelation = relations(
   issueToAssignees,

--- a/src/lib/server/db/schema/label.sql.ts
+++ b/src/lib/server/db/schema/label.sql.ts
@@ -1,4 +1,10 @@
-import { serial, varchar, integer, primaryKey } from "drizzle-orm/pg-core";
+import {
+  serial,
+  varchar,
+  integer,
+  primaryKey,
+  index
+} from "drizzle-orm/pg-core";
 
 import {
   relations,
@@ -32,7 +38,9 @@ export const labelToIssues = pgTable(
       })
   },
   (table) => ({
-    pk: primaryKey(table.issue_id, table.label_id)
+    pk: primaryKey(table.issue_id, table.label_id),
+    issueFkIndex: index("lbl_2_iss_issue_fk_index").on(table.issue_id),
+    assigneeFkIndex: index("lbl_2_iss_assignee_fk_index").on(table.label_id)
   })
 );
 

--- a/src/lib/server/db/schema/mention.sql.ts
+++ b/src/lib/server/db/schema/mention.sql.ts
@@ -1,4 +1,4 @@
-import { integer, serial, unique, varchar } from "drizzle-orm/pg-core";
+import { index, integer, serial, unique, varchar } from "drizzle-orm/pg-core";
 import { pgTable } from "./index.sql";
 import { issues } from "./issue.sql";
 import { comments } from "./comment.sql";
@@ -24,6 +24,8 @@ export const issueUserMentions = pgTable(
     })
   },
   (table) => ({
+    username_idx: index("ment_username_idx").on(table.username),
+    issue_idx: index("ment_issue_idx").on(table.issue_id),
     unique_idx: unique().on(table.username, table.issue_id, table.comment_id)
   })
 );

--- a/src/lib/server/db/schema/reaction.sql.ts
+++ b/src/lib/server/db/schema/reaction.sql.ts
@@ -1,5 +1,11 @@
-import { serial, integer, pgEnum } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import {
+  serial,
+  integer,
+  pgEnum,
+  index,
+  pgMaterializedView
+} from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
 import { users } from "./user.sql";
 import { issues } from "./issue.sql";
 import { comments } from "./comment.sql";
@@ -30,19 +36,71 @@ export const reactionTypeEnum = pgEnum("reaction_type", [
   "EYES"
 ]);
 
-export const reactions = pgTable("reactions", {
-  id: serial("id").primaryKey(),
-  type: reactionTypeEnum("type").notNull(),
-  author_id: integer("author_id").references(() => users.id, {
-    onDelete: "set null"
-  }),
-  comment_id: integer("comment_id").references(() => comments.id, {
-    onDelete: "cascade"
-  }),
-  issue_id: integer("issue_id").references(() => issues.id, {
-    onDelete: "cascade"
+export const reactions = pgTable(
+  "reactions",
+  {
+    id: serial("id").primaryKey(),
+    type: reactionTypeEnum("type").notNull(),
+    author_id: integer("author_id").references(() => users.id, {
+      onDelete: "set null"
+    }),
+    comment_id: integer("comment_id").references(() => comments.id, {
+      onDelete: "cascade"
+    }),
+    issue_id: integer("issue_id").references(() => issues.id, {
+      onDelete: "cascade"
+    })
+  },
+  (table) => ({
+    authorFKIdx: index("rakt_author_fk_idx").on(table.author_id),
+    typeIdx: index("rakt_type_idx").on(table.type),
+    issueFKIdx: index("rakt_issue_fk_idx").on(table.issue_id),
+    commentFKIdx: index("rakt_comment_fk_idx").on(table.comment_id)
   })
-});
+);
+
+export const reactionsCountPerIssue = pgMaterializedView(
+  "reaction_count_per_issue"
+).as((qb) =>
+  qb
+    .select({
+      issue_id: reactions.issue_id,
+      plus_one_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.PLUS_ONE} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("plus_one_count"),
+      minus_one_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.MINUS_ONE} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("minus_one_count"),
+      confused_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.CONFUSED} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("confused_count"),
+      eyes_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.EYES} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("eyes_count"),
+      heart_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.HEART} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("heart_count"),
+      hooray_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.HOORAY} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("hooray_count"),
+      laugh_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.LAUGH} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("laugh_count"),
+      rocket_count:
+        sql<number>`COALESCE(SUM(CASE WHEN ${reactions.type} = ${ReactionTypes.ROCKET} THEN 1 ELSE 0 END), 0)`
+          .mapWith(Number)
+          .as("rocket_count")
+    })
+    .from(reactions)
+    .groupBy(reactions.issue_id)
+);
 
 export const reactionsRelations = relations(reactions, ({ one }) => ({
   author: one(users, {

--- a/src/lib/server/db/schema/repository.sql.ts
+++ b/src/lib/server/db/schema/repository.sql.ts
@@ -24,7 +24,8 @@ export const repositories = pgTable(
     is_public: boolean("is_public").default(true)
   },
   (table) => ({
-    nameIdx: index("name_idx").on(table.name)
+    nameIdx: index("repo_name_idx").on(table.name),
+    creatorFkIdx: index("repo_creator_fk_idx").on(table.creator_id)
   })
 );
 


### PR DESCRIPTION
## Description

This PR add some fixes for the DB performance, notably by adding indexes on foreign keys, by reducing our usage of the `ilike` for username matching in favor of `eq (=)`, and by creating 2 materialized views for 2 queries `comments_count` and `reactions_count`, since materialized views don't get automatically updated, i created a trigger that will update them on INSERT & DELETE on the corresponding tables.


fixes #93 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

