### PR TITLE
Make it so that the BUILD_ID is only ever read once in the server lifetime

### DIFF
--- a/src/components/cache.tsx
+++ b/src/components/cache.tsx
@@ -1,15 +1,13 @@
 import { createCacheComponent } from "@rsc-cache/next";
-import { cache } from "react";
 import fs from "fs/promises";
 import { kv } from "~/lib/server/kv/index.server";
 import { DEFAULT_CACHE_TTL } from "~/lib/shared/constants";
+import { lifetimeCache } from "~/lib/shared/lifetime-cache";
 
-const devBuildId = new Date().getTime().toString();
-const getBuildId = cache(async () => {
-  if (process.env.NODE_ENV === "development") {
-    return devBuildId;
-  }
-  return await fs.readFile(".next/BUILD_ID", "utf-8");
+const getBuildId = lifetimeCache(async () => {
+  return process.env.NODE_ENV === "development"
+    ? new Date().getTime().toString()
+    : await fs.readFile(".next/BUILD_ID", "utf-8");
 });
 
 export const Cache = createCacheComponent({

--- a/src/components/custom-rsc-renderer/rsc-client-renderer.tsx
+++ b/src/components/custom-rsc-renderer/rsc-client-renderer.tsx
@@ -4,7 +4,7 @@ import * as RSDWSSr from "react-server-dom-webpack/client.edge";
 import * as RSDW from "react-server-dom-webpack/client";
 
 import { getSSRManifest } from "./rsc-manifest";
-import { fnCache } from "~/lib/shared/fn-cache";
+import { lifetimeCache } from "~/lib/shared/lifetime-cache";
 
 export type RscClientRendererProps = {
   payloadOrPromise: string | Promise<string>;
@@ -18,7 +18,7 @@ export function RscClientRenderer({
   return React.use(renderPayloadOrPromiseToJSX(payloadOrPromise, withSSR));
 }
 
-export const renderPayloadOrPromiseToJSX = fnCache(
+export const renderPayloadOrPromiseToJSX = lifetimeCache(
   async function resolveElement(
     payloadOrPromise: string | Promise<string>,
     ssr = false

--- a/src/lib/shared/lifetime-cache.ts
+++ b/src/lib/shared/lifetime-cache.ts
@@ -1,6 +1,13 @@
 /**
  * Custom `cache` but for caching items for the scope for the lifetime of the server,
  * on the client it will cache the result until the tab is refreshed.
+ *
+ * It has the same behavior as React `cache`, when called with the same arguments, it will
+ * return the cached result, if you give it other arguments, it will return a different result
+ * and cache that.
+ *
+ * However this cache is not limitless, it acts as an LRU cache with only a limited set of items in it
+ * and evicts the least recently used items.
  */
 export function lifetimeCache<T extends (...args: any[]) => Promise<any>>(
   fn: T


### PR DESCRIPTION
## Description

This PR is in response to a suggestion **bylubieowoce** to make it so that we don't read the BUILD_ID on every request  https://x.com/lubieowoce/status/1741255877108101466?s=20

I couldn't make it so that the BUILD_ID is exported at the top of the file since next will try to compile the file and throw an error because the file `.next/BUILD_ID` doesn't exist at build time. So to mitigate this, we replaced the `cache` function from next with our custom `lifetimeCache` function which caches the results of operations for the whole the server lifetime, this way the BUILD_ID isn't read at build time, but only read at runtime once.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- PLEASE UNCOMMENT THIS IF YOU ARE AN EXTERNAL CONTRIBUTOR
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your environment configuration.

Steps :

1. ...
2. ...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

## ! For Breaking Changes !

Please describe the steps & configuration needed to upgrade the project.
-->