### PR TITLE
Fix Top progress bar not finishing when the user open a new tab or window when clicking on a link

### DIFF
--- a/src/components/top-loader.tsx
+++ b/src/components/top-loader.tsx
@@ -20,5 +20,22 @@ function FinishingLoader() {
   React.useEffect(() => {
     NProgress.done();
   }, [pathname, router, searchParams]);
+  React.useEffect(() => {
+    const linkClickListener = (ev: MouseEvent) => {
+      const element = ev.target as HTMLElement;
+      const closestlink = element.closest("a");
+      const isOpenToNewTabClick =
+        ev.ctrlKey ||
+        ev.shiftKey ||
+        ev.metaKey || // apple
+        (ev.button && ev.button == 1); // middle click, >IE9 + everyone else
+
+      if (closestlink && isOpenToNewTabClick) {
+        NProgress.done();
+      }
+    };
+    window.addEventListener("click", linkClickListener);
+    return () => window.removeEventListener("click", linkClickListener);
+  }, []);
   return null;
 }


### PR DESCRIPTION
## Description

When the user clicks on a link with ctrl+click, the progress bar wouldn't finish, this PR fixes it.

![image](https://github.com/Fredkiss3/gh-next/assets/38298743/d496c28a-65e5-4bae-8747-1f32de2d45bc)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- PLEASE UNCOMMENT THIS IF YOU ARE AN EXTERNAL CONTRIBUTOR
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your environment configuration.

Steps :

1. ...
2. ...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

## ! For Breaking Changes !

Please describe the steps & configuration needed to upgrade the project.
-->